### PR TITLE
Add Reserve/Additional Source Switches and Operational Mode Select

### DIFF
--- a/custom_components/kronoterm/const.py
+++ b/custom_components/kronoterm/const.py
@@ -90,6 +90,17 @@ API_PARAM_KEYS = {
     "ANTILEGIONELLA": "antilegionella",
     "CIRCULATION": "circulation_on",
     "FAST_HEATING": "water_heating_on",
+    "RESERVE_SOURCE": "reserve_source_on",  # Fixed: was "reserve_source"
+    "ADDITIONAL_SOURCE": "additional_source_on",  # Fixed: was "additional_source"
+    # Main settings parameters
+    "MAIN_MODE": "main_mode",
+}
+
+# Operational mode mapping (ECO/Auto/Comfort)
+MAIN_MODE_OPTIONS = {
+    0: "auto",
+    1: "eco",
+    2: "comfort",
 }
 
 # Static form data for consumption fetching

--- a/custom_components/kronoterm/switch.py
+++ b/custom_components/kronoterm/switch.py
@@ -75,6 +75,18 @@ async def async_setup_entry(
             "antilegionella",
             "async_set_antilegionella",
         ),
+        SwitchConfig(
+            "reserve_source_switch",
+            "reserve_source_switch",
+            "reserve_source",
+            "async_set_reserve_source",
+        ),
+        SwitchConfig(
+            "additional_source_switch",
+            "additional_source_switch",
+            "additional_source",
+            "async_set_additional_source",
+        ),
     ]
 
     entities = [

--- a/custom_components/kronoterm/translations/de.json
+++ b/custom_components/kronoterm/translations/de.json
@@ -127,14 +127,24 @@
         "fast_heating_switch": { "name": "Schnelles Wasserheizen" },
         "antilegionella_switch": { "name": "Antilegionellen" },
         "loop1_temp_source_switch": { "name": "Loop 1 JSON-Temp-Quelle verwenden" },
-        "reservoir_entity_switch": { "name": "Speicher-Klima-Entität aktivieren" }
+        "reservoir_entity_switch": { "name": "Speicher-Klima-Entität aktivieren" },
+        "reserve_source_switch": { "name": "Reservequelle (Elektroheizung)" },
+        "additional_source_switch": { "name": "Zusätzliche Quelle" }
       },
       "select": {
         "loop_1_operation": { "name": "Betriebsmodus Loop 1" },
         "loop_2_operation": { "name": "Betriebsmodus Loop 2" },
         "loop_3_operation": { "name": "Betriebsmodus Loop 3" },
         "loop_4_operation": { "name": "Betriebsmodus Loop 4" },
-        "sanitary_water_operation": { "name": "Betriebsmodus Warmwasser" }
+        "sanitary_water_operation": { "name": "Betriebsmodus Warmwasser" },
+        "operational_mode": {
+          "name": "Betriebsmodus",
+          "state": {
+            "auto": "Automatisch",
+            "comfort": "Komfort",
+            "eco": "ECO"
+          }
+        }
       },
       "number": {
         "loop_1_eco_offset": { "name": "Loop 1 ECO‑Versatz" },

--- a/custom_components/kronoterm/translations/en.json
+++ b/custom_components/kronoterm/translations/en.json
@@ -39,59 +39,161 @@
   },
   "entity": {
     "binary_sensor": {
-      "circulation_loop_1": { "name": "Circulation Loop 1" },
-      "circulation_loop_2": { "name": "Circulation Loop 2" },
-      "circulation_loop_3": { "name": "Circulation Loop 3" },
-      "circulation_loop_4": { "name": "Circulation Loop 4" },
-      "circulation_dhw": { "name": "Circulation DHW" },
-      "additional_source": { "name": "Additional Source" },
-      "thermostat_loop_1": { "name": "Thermostat Loop 1 Active" },
-      "thermostat_loop_2": { "name": "Thermostat Loop 2 Active" },
-      "thermostat_loop_3": { "name": "Thermostat Loop 3 Active" },
-      "thermostat_loop_4": { "name": "Thermostat Loop 4 Active" }
+      "circulation_loop_1": {
+        "name": "Circulation Loop 1"
+      },
+      "circulation_loop_2": {
+        "name": "Circulation Loop 2"
+      },
+      "circulation_loop_3": {
+        "name": "Circulation Loop 3"
+      },
+      "circulation_loop_4": {
+        "name": "Circulation Loop 4"
+      },
+      "circulation_dhw": {
+        "name": "Circulation DHW"
+      },
+      "additional_source": {
+        "name": "Additional Source"
+      },
+      "thermostat_loop_1": {
+        "name": "Thermostat Loop 1 Active"
+      },
+      "thermostat_loop_2": {
+        "name": "Thermostat Loop 2 Active"
+      },
+      "thermostat_loop_3": {
+        "name": "Thermostat Loop 3 Active"
+      },
+      "thermostat_loop_4": {
+        "name": "Thermostat Loop 4 Active"
+      }
     },
     "sensor": {
-      "pool_temperature": { "name": "Pool Temperature" },
-      "alternative_source_temperature": { "name": "Alternative Source Temperature" },
-      "compressor_activations_cooling": { "name": "Compressor Activations - Cooling" },
-      "heating_source_pressure_set": { "name": "Pressure Setting Heating Source" },
-      "source_pressure": { "name": "Source Pressure" },
-      "energy_heating": { "name": "Energy Heating (Daily)" },
-      "energy_dhw": { "name": "Energy DHW (Daily)" },
-      "energy_circulation": { "name": "Energy Circulation (Daily)" },
-      "energy_heater": { "name": "Energy Heater (Daily)" },
-      "energy_combined": { "name": "Energy Combined (Daily)" },
-      "operating_hours_compressor_heating": { "name": "Operating Hours Compressor Heating" },
-      "operating_hours_compressor_dhw": { "name": "Operating Hours Compressor DHW" },
-      "operating_hours_additional_source_1": { "name": "Operating Hours Additional Source 1" },
-      "temperature_outside": { "name": "Temperature Outside" },
-      "hp_outlet_temperature": { "name": "Temperature HP Outlet" },
-      "hp_inlet_temperature": { "name": "Temperature HP Inlet" },
-      "temperature_compressor_inlet": { "name": "Temperature Compressor Inlet" },
-      "temperature_compressor_outlet": { "name": "Temperature Compressor Outlet" },
-      "pressure_setting": { "name": "Pressure Setting" },
-      "heating_system_pressure": { "name": "Heating System Pressure" },
-      "hp_load": { "name": "HP Load" },
-      "current_heating_cooling_capacity": { "name": "Current Heating/Cooling Capacity" },
-      "cop_value": { "name": "COP Value" },
-      "scop_value": { "name": "SCOP Value" },
-      "compressor_activations_heating": { "name": "Compressor Activations - Heating (24 h)" },
-      "activations_boiler": { "name": "Activations Boiler (24 h)" },
-      "activations_defrost": { "name": "Activations Defrost (24 h)" },
-      "electrical_energy_heating_dhw": { "name": "Electrical Energy Heating + DHW" },
-      "heating_energy_heating_dhw": { "name": "Heating Energy Heating + DHW" },
-      "loop_1_temperature": { "name": "Loop 1 Temperature" },
-      "loop_2_temperature": { "name": "Loop 2 Temperature" },
-      "loop_3_temperature": { "name": "Loop 3 Temperature" },
-      "loop_4_temperature": { "name": "Loop 4 Temperature" },
-      "loop_1_thermostat_temperature": { "name": "Loop 1 Thermostat Temperature" },
-      "loop_2_thermostat_temperature": { "name": "Loop 2 Thermostat Temperature" },
-      "loop_3_thermostat_temperature": { "name": "Loop 3 Thermostat Temperature" },
-      "loop_4_thermostat_temperature": { "name": "Loop 4 Thermostat Temperature" },
-      "loop_1_inlet_temperature":{ "name": "Loop 1 Inlet Temperature" },
-      "loop_2_inlet_temperature":{ "name": "Loop 2 Inlet Temperature" },
-      "loop_3_inlet_temperature":{ "name": "Loop 3 Inlet Temperature" },
-      "loop_4_inlet_temperature":{ "name": "Loop 4 Inlet Temperature" },
+      "pool_temperature": {
+        "name": "Pool Temperature"
+      },
+      "alternative_source_temperature": {
+        "name": "Alternative Source Temperature"
+      },
+      "compressor_activations_cooling": {
+        "name": "Compressor Activations - Cooling"
+      },
+      "heating_source_pressure_set": {
+        "name": "Pressure Setting Heating Source"
+      },
+      "source_pressure": {
+        "name": "Source Pressure"
+      },
+      "energy_heating": {
+        "name": "Energy Heating (Daily)"
+      },
+      "energy_dhw": {
+        "name": "Energy DHW (Daily)"
+      },
+      "energy_circulation": {
+        "name": "Energy Circulation (Daily)"
+      },
+      "energy_heater": {
+        "name": "Energy Heater (Daily)"
+      },
+      "energy_combined": {
+        "name": "Energy Combined (Daily)"
+      },
+      "operating_hours_compressor_heating": {
+        "name": "Operating Hours Compressor Heating"
+      },
+      "operating_hours_compressor_dhw": {
+        "name": "Operating Hours Compressor DHW"
+      },
+      "operating_hours_additional_source_1": {
+        "name": "Operating Hours Additional Source 1"
+      },
+      "temperature_outside": {
+        "name": "Temperature Outside"
+      },
+      "hp_outlet_temperature": {
+        "name": "Temperature HP Outlet"
+      },
+      "hp_inlet_temperature": {
+        "name": "Temperature HP Inlet"
+      },
+      "temperature_compressor_inlet": {
+        "name": "Temperature Compressor Inlet"
+      },
+      "temperature_compressor_outlet": {
+        "name": "Temperature Compressor Outlet"
+      },
+      "pressure_setting": {
+        "name": "Pressure Setting"
+      },
+      "heating_system_pressure": {
+        "name": "Heating System Pressure"
+      },
+      "hp_load": {
+        "name": "HP Load"
+      },
+      "current_heating_cooling_capacity": {
+        "name": "Current Heating/Cooling Capacity"
+      },
+      "cop_value": {
+        "name": "COP Value"
+      },
+      "scop_value": {
+        "name": "SCOP Value"
+      },
+      "compressor_activations_heating": {
+        "name": "Compressor Activations - Heating (24 h)"
+      },
+      "activations_boiler": {
+        "name": "Activations Boiler (24 h)"
+      },
+      "activations_defrost": {
+        "name": "Activations Defrost (24 h)"
+      },
+      "electrical_energy_heating_dhw": {
+        "name": "Electrical Energy Heating + DHW"
+      },
+      "heating_energy_heating_dhw": {
+        "name": "Heating Energy Heating + DHW"
+      },
+      "loop_1_temperature": {
+        "name": "Loop 1 Temperature"
+      },
+      "loop_2_temperature": {
+        "name": "Loop 2 Temperature"
+      },
+      "loop_3_temperature": {
+        "name": "Loop 3 Temperature"
+      },
+      "loop_4_temperature": {
+        "name": "Loop 4 Temperature"
+      },
+      "loop_1_thermostat_temperature": {
+        "name": "Loop 1 Thermostat Temperature"
+      },
+      "loop_2_thermostat_temperature": {
+        "name": "Loop 2 Thermostat Temperature"
+      },
+      "loop_3_thermostat_temperature": {
+        "name": "Loop 3 Thermostat Temperature"
+      },
+      "loop_4_thermostat_temperature": {
+        "name": "Loop 4 Thermostat Temperature"
+      },
+      "loop_1_inlet_temperature": {
+        "name": "Loop 1 Inlet Temperature"
+      },
+      "loop_2_inlet_temperature": {
+        "name": "Loop 2 Inlet Temperature"
+      },
+      "loop_3_inlet_temperature": {
+        "name": "Loop 3 Inlet Temperature"
+      },
+      "loop_4_inlet_temperature": {
+        "name": "Loop 4 Inlet Temperature"
+      },
       "working_function": {
         "name": "Working Function",
         "state": {
@@ -122,41 +224,113 @@
       }
     },
     "switch": {
-      "heatpump_switch": { "name": "Heat Pump ON/OFF" },
-      "dhw_circulation_switch": { "name": "DHW Circulation" },
-      "fast_heating_switch": { "name": "Fast Water Heating" },
-      "antilegionella_switch": { "name": "Antilegionella" },
-      "loop1_temp_source_switch": { "name": "Loop 1 Use JSON Temp Source" },
-      "reservoir_entity_switch": { "name": "Enable Reservoir Climate Entity" }
+      "heatpump_switch": {
+        "name": "Heat Pump ON/OFF"
+      },
+      "dhw_circulation_switch": {
+        "name": "DHW Circulation"
+      },
+      "fast_heating_switch": {
+        "name": "Fast Water Heating"
+      },
+      "antilegionella_switch": {
+        "name": "Antilegionella"
+      },
+      "loop1_temp_source_switch": {
+        "name": "Loop 1 Use JSON Temp Source"
+      },
+      "reservoir_entity_switch": {
+        "name": "Enable Reservoir Climate Entity"
+      },
+      "reserve_source_switch": {
+        "name": "Reserve Source (Backup Heater)"
+      },
+      "additional_source_switch": {
+        "name": "Additional Source"
+      }
     },
     "select": {
-      "loop_1_operation": { "name": "Loop 1 Operation Mode" },
-      "loop_2_operation": { "name": "Loop 2 Operation Mode" },
-      "loop_3_operation": { "name": "Loop 3 Operation Mode" },
-      "loop_4_operation": { "name": "Loop 4 Operation Mode" },
-      "sanitary_water_operation": { "name": "DHW Operation Mode" }
+      "loop_1_operation": {
+        "name": "Loop 1 Operation Mode"
+      },
+      "loop_2_operation": {
+        "name": "Loop 2 Operation Mode"
+      },
+      "loop_3_operation": {
+        "name": "Loop 3 Operation Mode"
+      },
+      "loop_4_operation": {
+        "name": "Loop 4 Operation Mode"
+      },
+      "sanitary_water_operation": {
+        "name": "DHW Operation Mode"
+      },
+      "operational_mode": {
+        "name": "Operational Mode",
+        "state": {
+          "auto": "Auto",
+          "comfort": "Comfort",
+          "eco": "ECO"
+        }
+      }
     },
     "number": {
-      "loop_1_eco_offset": { "name": "Loop 1 Eco Offset" },
-      "loop_1_comfort_offset": { "name": "Loop 1 Comfort Offset" },
-      "loop_2_eco_offset": { "name": "Loop 2 Eco Offset" },
-      "loop_2_comfort_offset": { "name": "Loop 2 Comfort Offset" },
-      "loop_3_eco_offset": { "name": "Loop 3 Eco Offset" },
-      "loop_3_comfort_offset": { "name": "Loop 3 Comfort Offset" },
-      "loop_4_eco_offset": { "name": "Loop 4 Eco Offset" },
-      "loop_4_comfort_offset": { "name": "Loop 4 Comfort Offset" },
-      "dhw_eco_offset": { "name": "DHW Eco Offset" },
-      "dhw_comfort_offset": { "name": "DHW Comfort Offset" },
-      "update_interval": { "name": "Update Interval (min)" },
-      "main_temperature_offset": { "name": "System temperature offset"}
+      "loop_1_eco_offset": {
+        "name": "Loop 1 Eco Offset"
+      },
+      "loop_1_comfort_offset": {
+        "name": "Loop 1 Comfort Offset"
+      },
+      "loop_2_eco_offset": {
+        "name": "Loop 2 Eco Offset"
+      },
+      "loop_2_comfort_offset": {
+        "name": "Loop 2 Comfort Offset"
+      },
+      "loop_3_eco_offset": {
+        "name": "Loop 3 Eco Offset"
+      },
+      "loop_3_comfort_offset": {
+        "name": "Loop 3 Comfort Offset"
+      },
+      "loop_4_eco_offset": {
+        "name": "Loop 4 Eco Offset"
+      },
+      "loop_4_comfort_offset": {
+        "name": "Loop 4 Comfort Offset"
+      },
+      "dhw_eco_offset": {
+        "name": "DHW Eco Offset"
+      },
+      "dhw_comfort_offset": {
+        "name": "DHW Comfort Offset"
+      },
+      "update_interval": {
+        "name": "Update Interval (min)"
+      },
+      "main_temperature_offset": {
+        "name": "System temperature offset"
+      }
     },
     "climate": {
-      "dhw_temperature": { "name": "DHW Temperature" },
-      "loop_1_temperature": { "name": "Loop 1 Temperature" },
-      "loop_2_temperature": { "name": "Loop 2 Temperature" },
-      "loop_3_temperature": { "name": "Loop 3 Temperature" },
-      "loop_4_temperature": { "name": "Loop 4 Temperature" },
-      "reservoir_temperature": { "name": "Reservoir Temperature" }
+      "dhw_temperature": {
+        "name": "DHW Temperature"
+      },
+      "loop_1_temperature": {
+        "name": "Loop 1 Temperature"
+      },
+      "loop_2_temperature": {
+        "name": "Loop 2 Temperature"
+      },
+      "loop_3_temperature": {
+        "name": "Loop 3 Temperature"
+      },
+      "loop_4_temperature": {
+        "name": "Loop 4 Temperature"
+      },
+      "reservoir_temperature": {
+        "name": "Reservoir Temperature"
+      }
     }
   }
 }

--- a/custom_components/kronoterm/translations/it.json
+++ b/custom_components/kronoterm/translations/it.json
@@ -127,14 +127,24 @@
       "fast_heating_switch": { "name": "Riscaldamento Rapido dell'Acqua" },
       "antilegionella_switch": { "name": "Antilegionella" },
       "loop1_temp_source_switch": { "name": "Circuito 1 Usa Sorgente Temp JSON" },
-      "reservoir_entity_switch": { "name": "Abilita Entità Clima Serbatoio" }
+      "reservoir_entity_switch": { "name": "Abilita Entità Clima Serbatoio" },
+      "reserve_source_switch": { "name": "Fonte di Riserva (Riscaldatore Elettrico)" },
+      "additional_source_switch": { "name": "Fonte Aggiuntiva" }
     },
     "select": {
       "loop_1_operation": { "name": "Modalità Operativa Circuito 1" },
       "loop_2_operation": { "name": "Modalità Operativa Circuito 2" },
       "loop_3_operation": { "name": "Modalità Operativa Circuito 3" },
       "loop_4_operation": { "name": "Modalità Operativa Circuito 4" },
-      "sanitary_water_operation": { "name": "Modalità Operativa ACS" }
+      "sanitary_water_operation": { "name": "Modalità Operativa ACS" },
+      "operational_mode": {
+        "name": "Modalità Operativa",
+        "state": {
+          "auto": "Automatico",
+          "comfort": "Comfort",
+          "eco": "ECO"
+        }
+      }
     },
     "number": {
       "loop_1_eco_offset": { "name": "Scarto ECO Circuito 1" },

--- a/custom_components/kronoterm/translations/sl.json
+++ b/custom_components/kronoterm/translations/sl.json
@@ -127,14 +127,24 @@
         "fast_heating_switch": { "name": "Hitro segrevanje vode" },
         "antilegionella_switch": { "name": "Antilegionella" },
         "loop1_temp_source_switch": { "name": "Zanka 1 Uporabi JSON Vir Temp" },
-        "reservoir_entity_switch": { "name": "Omogoči entiteto klime rezervoarja" }
+        "reservoir_entity_switch": { "name": "Omogoči entiteto klime rezervoarja" },
+        "reserve_source_switch": { "name": "Rezervni vir (električni grelnik)" },
+        "additional_source_switch": { "name": "Dodatni vir" }
       },
       "select": {
         "loop_1_operation": { "name": "Način delovanja zanke 1" },
         "loop_2_operation": { "name": "Način delovanja zanke 2" },
         "loop_3_operation": { "name": "Način delovanja zanke 3" },
         "loop_4_operation": { "name": "Način delovanja zanke 4" },
-        "sanitary_water_operation": { "name": "Način delovanja sanitarne vode" }
+        "sanitary_water_operation": { "name": "Način delovanja sanitarne vode" },
+        "operational_mode": {
+          "name": "Način obratovanja",
+          "state": {
+            "auto": "Samodejno",
+            "comfort": "Udobje",
+            "eco": "ECO"
+          }
+        }
       },
       "number": {
         "loop_1_eco_offset": { "name": "ECO odmik zanke 1" },


### PR DESCRIPTION
## Summary
This PR adds three new entities to the Kronoterm integration:
1. **Reserve Source Switch** - Controls the backup electric heater
2. **Additional Source Switch** - Controls additional heating source (if available)
3. **Operational Mode Select** - Allows changing between Auto/ECO/Comfort modes

Closes #22 (reserve heating source switch)
Closes #24 (operational mode selector)

## New Features

### Reserve Source Switch
- Entity: `switch.kronoterm_reserve_source`
- Controls the backup electric heater
- Uses confirmation handler for API dialogs
- Fully tested on real hardware

### Additional Source Switch
- Entity: `switch.kronoterm_additional_source`
- Controls additional heating source (if installed)
- Uses confirmation handler for API dialogs
- Fully tested on real hardware

### Operational Mode Select
- Entity: `select.kronoterm_operational_mode`
- Options: Auto / ECO / Comfort
- Reads from `main_settings.AdvancedSettings.main_mode`
- Proper entity naming with translations

## Technical Changes

### Modified Files
- **const.py**: Added parameter mappings for `reserve_source_on`, `additional_source_on`, and `main_mode`
- **coordinator.py**: Added `async_set_reserve_source()`, `async_set_additional_source()`, and `async_set_main_mode()` methods
- **switch.py**: Added two new switch configurations
- **select.py**: Added `KronotermOperationalModeSelect` class with `_attr_has_entity_name = True`
- **translations/*.json**: Added EN/SL/DE/IT translations for all new entities

### API Implementation
- **Endpoints**: Shortcuts (TopPage=1, Subpage=3) and Main Settings (TopPage=3, Subpage=11)
- **Critical fix**: Each switch sends only its own parameter (not both together) - matches web app behavior
- **Confirmation handling**: Both switches use `_async_set_shortcut_with_confirm()` for API confirmation dialogs
- **Mode mapping**: 0=auto, 1=eco, 2=comfort (fixed incorrect eco/comfort swap)

## Testing

Tested on real hardware (Kronoterm Hydro S + Adapt 0416-K3 HT / HK 3F):
- ✅ Reserve Source ON/OFF switching verified
- ✅ Additional Source ON/OFF switching verified
- ✅ Operational Mode state reading verified
- ✅ Operational Mode switching (Auto ↔ ECO ↔ Comfort) verified
- ✅ All entities show proper translated names
- ✅ No errors in Home Assistant logs

## Breaking Changes
None - this is purely additive functionality.

## Translations
Full translations provided for:
- 🇬🇧 English
- 🇸🇮 Slovenian
- 🇩🇪 German
- 🇮🇹 Italian

All entities follow Home Assistant naming conventions and integration patterns.