### PR TITLE
Fix energy statistics reimport and prepare v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2026-07-23 - v1.7.1
+
 ### Fixed
 - Reimport Energy Statistics now stops after a year of empty Cloud history,
   removes synthetic leading zero days, batches recorder writes, preserves the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Reimport Energy Statistics now stops after a year of empty Cloud history,
+  removes synthetic leading zero days, batches recorder writes, preserves the
+  historical-to-live cumulative handover in both hourly and five-minute
+  statistics, waits for the recorder to commit, and remains idempotent when
+  pressed repeatedly.
+
 ## 2026-07-22 - v1.7.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ ls /dev/tty* | grep -E "USB|AMA"
 ### Energy Monitoring
 ![Energy](images/energy.png)
 
-**Reimport warning:** Reimporting energy statistics clears existing statistics. Short‑term (hourly) bars may disappear until Home Assistant rebuilds them from recorder history.
+**Reimport behavior:** Reimporting energy statistics rebuilds the available Cloud
+history, joins it to the existing live series without a negative reset, and waits
+for Home Assistant's recorder to commit the result before reporting completion.
 
 [Example Dashboard YAML](dashboard.yaml)
 

--- a/custom_components/kronoterm/button.py
+++ b/custom_components/kronoterm/button.py
@@ -44,7 +44,10 @@ class KronotermReimportEnergyButton(CoordinatorEntity, ButtonEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         return {
-            "warning": "Reimport clears statistics. Short-term (hourly) stats may disappear until HA rebuilds them.",
+            "warning": (
+                "Reimport rebuilds available cloud history and preserves the "
+                "live statistics handover."
+            ),
         }
 
     def __init__(self, coordinator: Any, entry: ConfigEntry) -> None:

--- a/custom_components/kronoterm/const.py
+++ b/custom_components/kronoterm/const.py
@@ -1,7 +1,7 @@
 from typing import NamedTuple, Dict, List, Set, Any, Optional
 
 DOMAIN = "kronoterm"
-INTEGRATION_VERSION = "1.7.0"
+INTEGRATION_VERSION = "1.7.1"
 CONFIG_ENTRY_VERSION = 3
 BASE_URL = "https://cloud.kronoterm.com/jsoncgi.php"
 BASE_URL_DHW = "https://cloud.kronoterm.com/dhws/jsoncgi.php"

--- a/custom_components/kronoterm/coordinator.py
+++ b/custom_components/kronoterm/coordinator.py
@@ -4,7 +4,7 @@ import aiohttp
 import json
 import random
 import time
-from datetime import datetime, timedelta
+from datetime import date, datetime, time as datetime_time, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
 from aiohttp.client_exceptions import ClientError, ClientResponseError
@@ -25,6 +25,17 @@ from .identifiers import (
     ENERGY_DATA_KEYS,
     combined_energy_unique_id,
     daily_energy_unique_id,
+)
+from .energy_history import (
+    EMPTY_HISTORY_STOP_DAYS,
+    MAX_HISTORY_DAYS,
+    cumulative_energy_rows,
+    energy_window_has_data,
+    energy_window_length,
+    infer_previous_live_offset,
+    merge_energy_window,
+    normalize_energy_series,
+    trim_history_to_first_energy,
 )
 
 from .const import (
@@ -255,6 +266,7 @@ class KronotermMainCoordinator(KronotermBaseCoordinator):
         self._last_stats_sync_date = None
         self._energy_statistic_ids = None
         self._stats_metadata_reset = False
+        self._energy_reimport_lock = asyncio.Lock()
         self.previous_day_energy: dict[str, float] = {}
         self.previous_day_energy_date = None
 
@@ -680,103 +692,221 @@ class KronotermMainCoordinator(KronotermBaseCoordinator):
             return 0.0
         return float(rows[-1].get("sum") or 0.0)
 
+    async def _get_energy_statistics(
+        self,
+        entity_ids: set[str],
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Return enough hourly statistics to locate the live-data handover."""
+        start = dt_util.utcnow() - timedelta(days=MAX_HISTORY_DAYS)
+
+        def _fetch():
+            return statistics_during_period(
+                self.hass,
+                start,
+                None,
+                entity_ids,
+                "hour",
+                None,
+                {"sum"},
+            )
+
+        recorder = get_instance(self.hass)
+        return await recorder.async_add_executor_job(_fetch)
+
+    @staticmethod
+    def _statistics_start_as_local(value: Any) -> datetime | None:
+        """Normalize a statistics start value and convert it to local time."""
+        if isinstance(value, (int, float)):
+            value = dt_util.utc_from_timestamp(value)
+        elif isinstance(value, str):
+            value = dt_util.parse_datetime(value)
+        if not isinstance(value, datetime):
+            return None
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=dt_util.UTC)
+        return dt_util.as_local(value)
+
+    def _find_energy_handover_date(
+        self,
+        existing: dict[str, list[dict[str, Any]]],
+    ) -> date:
+        """Find the first day containing recorder-generated hourly rows."""
+        candidates: list[date] = []
+        for rows in existing.values():
+            for row in rows:
+                start = self._statistics_start_as_local(row.get("start"))
+                if start is None or start.time() == datetime_time.min:
+                    continue
+                candidates.append(start.date())
+                break
+
+        return min(candidates) if candidates else dt_util.now().date()
+
+    def _previous_energy_reimport_totals(
+        self,
+        handover_date: date,
+        existing: dict[str, list[dict[str, Any]]],
+    ) -> dict[str, float]:
+        """Infer offsets already applied at the historical/live boundary."""
+        previous: dict[str, float] = {}
+        for entity_id, rows in existing.items():
+            historical_sum = 0.0
+            first_live_sum: float | None = None
+            for row in rows:
+                start = self._statistics_start_as_local(row.get("start"))
+                if start is None:
+                    continue
+                row_sum = float(row.get("sum") or 0.0)
+                if start.date() < handover_date:
+                    historical_sum = row_sum
+                elif first_live_sum is None:
+                    first_live_sum = row_sum
+                    break
+
+            previous[entity_id] = infer_previous_live_offset(
+                historical_sum,
+                first_live_sum,
+            )
+        return previous
+
     async def reimport_all_energy_statistics(self) -> None:
-        """Re-import all available energy statistics by walking backwards until no data."""
+        """Rebuild available energy history and join it to live statistics."""
+        async with self._energy_reimport_lock:
+            await self._reimport_all_energy_statistics()
+
+    async def _reimport_all_energy_statistics(self) -> None:
+        """Perform one bounded, monotonic, idempotent energy-history import."""
         entity_ids = await self._get_energy_statistic_entity_ids()
         if not entity_ids:
             _LOGGER.warning("No energy statistic entities found for reimport")
             return
 
-        current = dt_util.now().date() - timedelta(days=1)
-        max_days = 3650
-        empty_days = 0
-        last_imported = None
-        day_values: dict[datetime.date, dict[str, float]] = {}
+        statistic_ids = set(entity_ids.values())
+        existing = await self._get_energy_statistics(statistic_ids)
+        handover_date = self._find_energy_handover_date(existing)
+        current = min(
+            dt_util.now().date() - timedelta(days=1),
+            handover_date - timedelta(days=1),
+        )
+        remaining_days = MAX_HISTORY_DAYS
+        empty_history_days = 0
+        day_values: dict[date, dict[str, float]] = {}
 
-        while max_days > 0:
+        while remaining_days > 0:
             consumption = await self._fetch_consumption_for_date(current)
             trend = consumption.get("trend_consumption") if consumption else None
             if trend:
-                keys = list(ENERGY_DATA_KEYS)
-                series_map = {k: [float(v) for v in trend.get(k, [])] for k in keys}
-                length = max((len(v) for v in series_map.values()), default=0)
-                if length == 0:
-                    empty_days += 1
-                else:
-                    window_start = current - timedelta(days=length - 1)
-                    for offset in range(length):
-                        day = window_start + timedelta(days=offset)
-                        if day in day_values:
-                            continue
-
-                        day_values[day] = {}
-                        for key, entity_id in entity_ids.items():
-                            if key == "combined":
-                                value = sum(
-                                    series_map.get(k, [0.0] * length)[offset]
-                                    if offset < len(series_map.get(k, [])) else 0.0
-                                    for k in keys
-                                )
-                            else:
-                                values = series_map.get(key, [])
-                                if offset >= len(values):
-                                    continue
-                                value = values[offset]
-
-                            day_values[day][entity_id] = value
-
-                    _LOGGER.info("Consumption window: %s → %s (len=%s)", window_start, window_start + timedelta(days=length - 1), length)
-                    last_imported = current
-                    empty_days = 0
+                series_map = normalize_energy_series(trend, ENERGY_DATA_KEYS)
+                length = energy_window_length(series_map)
+                if length:
+                    window = merge_energy_window(
+                        day_values,
+                        current,
+                        series_map,
+                        entity_ids,
+                        ENERGY_DATA_KEYS,
+                    )
+                    assert window is not None
+                    window_start, window_end = window
+                    has_energy = energy_window_has_data(series_map)
+                    _LOGGER.info(
+                        "Consumption window: %s -> %s (len=%s, energy=%s)",
+                        window_start,
+                        window_end,
+                        length,
+                        has_energy,
+                    )
+                    empty_history_days = (
+                        0 if has_energy else empty_history_days + length
+                    )
                     current = window_start - timedelta(days=1)
-                    max_days -= length
-                    continue
+                    remaining_days -= length
+                else:
+                    empty_history_days += 1
+                    current -= timedelta(days=1)
+                    remaining_days -= 1
             else:
-                _LOGGER.debug("No consumption data for %s (empty streak %s)", current, empty_days + 1)
-                empty_days += 1
+                empty_history_days += 1
+                current -= timedelta(days=1)
+                remaining_days -= 1
 
-            if empty_days >= 7:
-                _LOGGER.info("Stopping backward scan after %s consecutive empty days. Last imported: %s", empty_days, last_imported)
+            if empty_history_days >= EMPTY_HISTORY_STOP_DAYS:
+                _LOGGER.info(
+                    "Stopping backward scan after %s consecutive empty days",
+                    empty_history_days,
+                )
                 break
 
-            current -= timedelta(days=1)
-            max_days -= 1
+        day_values = trim_history_to_first_energy(day_values)
+        if not day_values:
+            _LOGGER.warning("No non-zero Kronoterm energy history found")
+            return
 
-        running_totals = {k: 0.0 for k in entity_ids.values()}
-        today = dt_util.now().date()
-        cutoff = today - timedelta(days=1)
-        _LOGGER.info("Importing up to day before yesterday. Today=%s, max_day=%s", today, max(day_values.keys()) if day_values else None)
-        for day in sorted(day_values.keys()):
-            if day >= cutoff:
-                continue
-            for entity_id, value in day_values[day].items():
-                running_totals[entity_id] += value
+        rows, totals = cumulative_energy_rows(
+            day_values,
+            statistic_ids,
+            handover_date,
+        )
+        previous_totals = self._previous_energy_reimport_totals(
+            handover_date,
+            existing,
+        )
+        recorder = get_instance(self.hass)
+
+        for entity_id in statistic_ids:
+            imported_rows = []
+            for day, running_total in rows[entity_id]:
                 start_local = datetime.combine(
                     day,
                     datetime.min.time(),
                     tzinfo=dt_util.DEFAULT_TIME_ZONE,
                 )
-                start = dt_util.as_utc(start_local)
-                metadata = {
-                    "statistic_id": entity_id,
-                    "source": "recorder",
-                    "name": entity_id,
-                    "unit_of_measurement": "kWh",
-                    "unit_class": "energy",
-                    "has_sum": True,
-                    "has_mean": False,
-                    "mean_type": StatisticMeanType.NONE,
-                }
-                stats = [{
-                    "start": start,
-                    "state": running_totals[entity_id],
-                    "sum": running_totals[entity_id],
+                imported_rows.append({
+                    "start": dt_util.as_utc(start_local),
+                    "state": running_total,
+                    "sum": running_total,
                     "last_reset": None,
-                }]
-                async_import_statistics(self.hass, metadata, stats)
+                })
 
+            metadata = {
+                "statistic_id": entity_id,
+                "source": "recorder",
+                "name": entity_id,
+                "unit_of_measurement": "kWh",
+                "unit_class": "energy",
+                "has_sum": True,
+                "has_mean": False,
+                "mean_type": StatisticMeanType.NONE,
+            }
+            async_import_statistics(self.hass, metadata, imported_rows)
+
+        handover_start = dt_util.as_utc(
+            datetime.combine(
+                handover_date,
+                datetime.min.time(),
+                tzinfo=dt_util.DEFAULT_TIME_ZONE,
+            )
+        )
+        for entity_id in statistic_ids:
+            adjustment = totals[entity_id] - previous_totals[entity_id]
+            if abs(adjustment) > 1e-9:
+                recorder.async_adjust_statistics(
+                    entity_id,
+                    handover_start,
+                    adjustment,
+                    "kWh",
+                )
+
+        await recorder.async_block_till_done()
         self._last_stats_sync_date = dt_util.now().date()
-        _LOGGER.info("Re-imported energy statistics for all available history (backward scan)")
+        _LOGGER.info(
+            "Re-imported %s days of energy statistics (%s -> %s); "
+            "live handover=%s",
+            len(day_values),
+            min(day_values),
+            max(day_values),
+            handover_date,
+        )
 
 
 class KronotermDHWCoordinator(KronotermBaseCoordinator):

--- a/custom_components/kronoterm/coordinator.py
+++ b/custom_components/kronoterm/coordinator.py
@@ -30,9 +30,9 @@ from .energy_history import (
     EMPTY_HISTORY_STOP_DAYS,
     MAX_HISTORY_DAYS,
     cumulative_energy_rows,
+    energy_handover_adjustment,
     energy_window_has_data,
     energy_window_length,
-    infer_previous_live_offset,
     merge_energy_window,
     normalize_energy_series,
     trim_history_to_first_energy,
@@ -742,32 +742,57 @@ class KronotermMainCoordinator(KronotermBaseCoordinator):
 
         return min(candidates) if candidates else dt_util.now().date()
 
-    def _previous_energy_reimport_totals(
+    def _energy_handover_adjustments(
         self,
         handover_date: date,
         existing: dict[str, list[dict[str, Any]]],
-    ) -> dict[str, float]:
-        """Infer offsets already applied at the historical/live boundary."""
-        previous: dict[str, float] = {}
+    ) -> dict[str, tuple[datetime, float]]:
+        """Calculate corrections at each entity's first actual live row."""
+        adjustments: dict[str, tuple[datetime, float]] = {}
         for entity_id, rows in existing.items():
             historical_sum = 0.0
             first_live_sum: float | None = None
+            first_live_start: datetime | None = None
             for row in rows:
                 start = self._statistics_start_as_local(row.get("start"))
                 if start is None:
                     continue
                 row_sum = float(row.get("sum") or 0.0)
-                if start.date() < handover_date:
+                is_midnight = (
+                    start.hour == 0
+                    and start.minute == 0
+                    and start.second == 0
+                    and start.microsecond == 0
+                )
+                if start.date() < handover_date or (
+                    start.date() == handover_date and is_midnight
+                ):
                     historical_sum = row_sum
-                elif first_live_sum is None:
+                elif start.date() >= handover_date and first_live_sum is None:
                     first_live_sum = row_sum
+                    first_live_start = start
                     break
 
-            previous[entity_id] = infer_previous_live_offset(
+            _LOGGER.debug(
+                "Energy boundary for %s: historical=%.6f, first_live=%s",
+                entity_id,
+                historical_sum,
+                (
+                    f"{first_live_sum:.6f}"
+                    if first_live_sum is not None
+                    else "missing"
+                ),
+            )
+            adjustment = energy_handover_adjustment(
                 historical_sum,
                 first_live_sum,
             )
-        return previous
+            if first_live_start is not None:
+                adjustments[entity_id] = (
+                    dt_util.as_utc(first_live_start),
+                    adjustment,
+                )
+        return adjustments
 
     async def reimport_all_energy_statistics(self) -> None:
         """Rebuild available energy history and join it to live statistics."""
@@ -842,14 +867,10 @@ class KronotermMainCoordinator(KronotermBaseCoordinator):
             _LOGGER.warning("No non-zero Kronoterm energy history found")
             return
 
-        rows, totals = cumulative_energy_rows(
+        rows, _totals = cumulative_energy_rows(
             day_values,
             statistic_ids,
             handover_date,
-        )
-        previous_totals = self._previous_energy_reimport_totals(
-            handover_date,
-            existing,
         )
         recorder = get_instance(self.hass)
 
@@ -880,19 +901,35 @@ class KronotermMainCoordinator(KronotermBaseCoordinator):
             }
             async_import_statistics(self.hass, metadata, imported_rows)
 
-        handover_start = dt_util.as_utc(
-            datetime.combine(
-                handover_date,
-                datetime.min.time(),
-                tzinfo=dt_util.DEFAULT_TIME_ZONE,
-            )
+        # Home Assistant may rewrite later sums while imported rows are merged.
+        # Wait for that work, inspect the resulting boundary, and only then join
+        # the live series to the final historical total. This is idempotent and
+        # also repairs offsets left by older versions of the integration.
+        await recorder.async_block_till_done()
+        post_import = await self._get_energy_statistics(statistic_ids)
+        adjustments = self._energy_handover_adjustments(
+            handover_date,
+            post_import,
         )
         for entity_id in statistic_ids:
-            adjustment = totals[entity_id] - previous_totals[entity_id]
+            correction = adjustments.get(entity_id)
+            if correction is None:
+                _LOGGER.debug(
+                    "No live statistics boundary found for %s",
+                    entity_id,
+                )
+                continue
+            first_live_start, adjustment = correction
+            _LOGGER.debug(
+                "Energy handover adjustment for %s at %s: %.6f kWh",
+                entity_id,
+                first_live_start,
+                adjustment,
+            )
             if abs(adjustment) > 1e-9:
                 recorder.async_adjust_statistics(
                     entity_id,
-                    handover_start,
+                    first_live_start,
                     adjustment,
                     "kWh",
                 )

--- a/custom_components/kronoterm/energy_history.py
+++ b/custom_components/kronoterm/energy_history.py
@@ -134,14 +134,12 @@ def cumulative_energy_rows(
     return rows, totals
 
 
-def infer_previous_live_offset(
+def energy_handover_adjustment(
     historical_sum: float,
     first_live_sum: float | None,
 ) -> float:
-    """Infer whether a prior import offset is already present on live rows."""
-    if (
-        first_live_sum is not None
-        and first_live_sum >= historical_sum - ENERGY_VALUE_EPSILON
-    ):
-        return historical_sum
-    return 0.0
+    """Return the correction that joins the first live row to history."""
+    if first_live_sum is None:
+        return 0.0
+    adjustment = historical_sum - first_live_sum
+    return 0.0 if abs(adjustment) <= ENERGY_VALUE_EPSILON else adjustment

--- a/custom_components/kronoterm/energy_history.py
+++ b/custom_components/kronoterm/energy_history.py
@@ -1,0 +1,147 @@
+"""Pure helpers for rebuilding Kronoterm daily energy statistics."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from datetime import date, timedelta
+import math
+
+
+ENERGY_VALUE_EPSILON = 1e-9
+MAX_HISTORY_DAYS = 3650
+EMPTY_HISTORY_STOP_DAYS = 366
+
+
+def normalize_energy_series(
+    trend: Mapping[str, object],
+    keys: Iterable[str],
+) -> dict[str, list[float]]:
+    """Return finite numeric daily series for the requested energy keys."""
+    normalized: dict[str, list[float]] = {}
+    for key in keys:
+        raw_values = trend.get(key, [])
+        if not isinstance(raw_values, (list, tuple)):
+            normalized[key] = []
+            continue
+
+        values: list[float] = []
+        for raw_value in raw_values:
+            try:
+                value = float(raw_value)
+            except (TypeError, ValueError):
+                value = 0.0
+            values.append(value if math.isfinite(value) else 0.0)
+        normalized[key] = values
+    return normalized
+
+
+def energy_window_length(series_map: Mapping[str, list[float]]) -> int:
+    """Return the longest series length in a consumption response."""
+    return max((len(values) for values in series_map.values()), default=0)
+
+
+def energy_window_has_data(series_map: Mapping[str, list[float]]) -> bool:
+    """Return whether a response contains any actual energy consumption."""
+    return any(
+        abs(value) > ENERGY_VALUE_EPSILON
+        for values in series_map.values()
+        for value in values
+    )
+
+
+def merge_energy_window(
+    day_values: dict[date, dict[str, float]],
+    window_end: date,
+    series_map: Mapping[str, list[float]],
+    entity_ids: Mapping[str, str],
+    energy_keys: Iterable[str],
+) -> tuple[date, date] | None:
+    """Merge one oldest-to-newest API window without duplicating days."""
+    length = energy_window_length(series_map)
+    if length == 0:
+        return None
+
+    keys = tuple(energy_keys)
+    window_start = window_end - timedelta(days=length - 1)
+    for offset in range(length):
+        day = window_start + timedelta(days=offset)
+        if day in day_values:
+            continue
+
+        values_for_day: dict[str, float] = {}
+        for key, entity_id in entity_ids.items():
+            if key == "combined":
+                values_for_day[entity_id] = sum(
+                    series_map.get(energy_key, [])[offset]
+                    if offset < len(series_map.get(energy_key, []))
+                    else 0.0
+                    for energy_key in keys
+                )
+                continue
+
+            values = series_map.get(key, [])
+            if offset < len(values):
+                values_for_day[entity_id] = values[offset]
+
+        day_values[day] = values_for_day
+
+    return window_start, window_end
+
+
+def trim_history_to_first_energy(
+    day_values: Mapping[date, dict[str, float]],
+) -> dict[date, dict[str, float]]:
+    """Drop synthetic leading zero days returned before installation."""
+    first_energy_day = next(
+        (
+            day
+            for day in sorted(day_values)
+            if any(
+                abs(value) > ENERGY_VALUE_EPSILON
+                for value in day_values[day].values()
+            )
+        ),
+        None,
+    )
+    if first_energy_day is None:
+        return {}
+
+    return {
+        day: dict(values)
+        for day, values in day_values.items()
+        if day >= first_energy_day
+    }
+
+
+def cumulative_energy_rows(
+    day_values: Mapping[date, dict[str, float]],
+    entity_ids: Iterable[str],
+    handover_date: date,
+) -> tuple[dict[str, list[tuple[date, float]]], dict[str, float]]:
+    """Build monotonic cumulative rows strictly before the live handover."""
+    entity_ids = tuple(entity_ids)
+    totals = {entity_id: 0.0 for entity_id in entity_ids}
+    rows = {entity_id: [] for entity_id in entity_ids}
+
+    for day in sorted(day_values):
+        if day >= handover_date:
+            continue
+        values = day_values[day]
+        for entity_id in entity_ids:
+            totals[entity_id] += max(0.0, float(values.get(entity_id, 0.0)))
+            rows[entity_id].append((day, totals[entity_id]))
+
+    return rows, totals
+
+
+def infer_previous_live_offset(
+    historical_sum: float,
+    first_live_sum: float | None,
+) -> float:
+    """Infer whether a prior import offset is already present on live rows."""
+    if (
+        first_live_sum is not None
+        and first_live_sum >= historical_sum - ENERGY_VALUE_EPSILON
+    ):
+        return historical_sum
+    return 0.0

--- a/custom_components/kronoterm/manifest.json
+++ b/custom_components/kronoterm/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "pymodbus>=3.5.0"
   ],
-  "version": "1.7.0"
+  "version": "1.7.1"
 }

--- a/custom_components/kronoterm/text.py
+++ b/custom_components/kronoterm/text.py
@@ -42,7 +42,8 @@ class KronotermEnergyReimportInfo(CoordinatorEntity, TextEntity):
         self._attr_unique_id = f"{entry.entry_id}_{DOMAIN}_energy_reimport_info"
         self._attr_device_info = coordinator.shared_device_info
         self._attr_native_value = (
-            "Reimport clears statistics. Hourly (short-term) stats may disappear until HA rebuilds them."
+            "Reimport rebuilds available cloud history and preserves the live "
+            "statistics handover."
         )
 
     async def async_set_value(self, value: str) -> None:

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -190,20 +190,27 @@ class EnergyHistoryTests(unittest.TestCase):
         ])
         self.assertEqual(day_values[date(2026, 1, 3)]["sensor.heating"], 3.0)
 
-    def test_previous_offset_is_inferred_without_double_application(self) -> None:
+    def test_handover_adjustment_joins_history_to_live_rows(self) -> None:
         history = load_component_module("energy_history")
 
-        self.assertEqual(history.infer_previous_live_offset(100.0, 3.0), 0.0)
-        self.assertEqual(history.infer_previous_live_offset(100.0, 100.0), 100.0)
-        self.assertEqual(history.infer_previous_live_offset(100.0, 105.0), 100.0)
-        self.assertEqual(history.infer_previous_live_offset(100.0, None), 0.0)
+        self.assertEqual(history.energy_handover_adjustment(100.0, 3.0), 97.0)
+        self.assertEqual(history.energy_handover_adjustment(100.0, 100.0), 0.0)
+        self.assertEqual(history.energy_handover_adjustment(100.0, 105.0), -5.0)
+        self.assertEqual(history.energy_handover_adjustment(100.0, None), 0.0)
 
     def test_coordinator_offsets_live_tables_and_waits_for_recorder(self) -> None:
         source = (COMPONENT / "coordinator.py").read_text(encoding="utf-8")
 
         self.assertIn("recorder.async_adjust_statistics(", source)
-        self.assertIn("await recorder.async_block_till_done()", source)
-        self.assertIn("_previous_energy_reimport_totals", source)
+        self.assertGreaterEqual(
+            source.count("await recorder.async_block_till_done()"),
+            2,
+        )
+        self.assertIn("_energy_handover_adjustments", source)
+        self.assertIn("post_import = await self._get_energy_statistics", source)
+        self.assertIn("start.date() == handover_date and is_midnight", source)
+        self.assertIn("first_live_start = start", source)
+        self.assertIn("recorder.async_adjust_statistics(\n                    entity_id,\n                    first_live_start,", source)
         self.assertIn("EMPTY_HISTORY_STOP_DAYS", source)
 
 

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+from datetime import date
 from pathlib import Path
 import sys
 import types
@@ -103,6 +104,107 @@ class IdentifierTests(unittest.TestCase):
             ),
             "modbus:tcp:10.0.0.42:502:20",
         )
+
+
+class EnergyHistoryTests(unittest.TestCase):
+    def test_zero_only_windows_are_not_treated_as_real_history(self) -> None:
+        history = load_component_module("energy_history")
+        series = history.normalize_energy_series(
+            {
+                "heating": [0, "0.0", None],
+                "dhw": [float("nan"), float("inf"), "bad"],
+            },
+            ("heating", "dhw"),
+        )
+
+        self.assertFalse(history.energy_window_has_data(series))
+        series["dhw"][-1] = 0.25
+        self.assertTrue(history.energy_window_has_data(series))
+
+    def test_import_trims_leading_zeros_and_keeps_monotonic_totals(self) -> None:
+        history = load_component_module("energy_history")
+        entity_ids = {
+            "heating": "sensor.heating",
+            "dhw": "sensor.dhw",
+            "combined": "sensor.combined",
+        }
+        day_values = {}
+        history.merge_energy_window(
+            day_values,
+            date(2026, 1, 4),
+            {
+                "heating": [0.0, 2.0, -1.0, 4.0],
+                "dhw": [0.0, 1.0, 0.5, 3.0],
+            },
+            entity_ids,
+            ("heating", "dhw"),
+        )
+
+        trimmed = history.trim_history_to_first_energy(day_values)
+        self.assertEqual(min(trimmed), date(2026, 1, 2))
+
+        rows, totals = history.cumulative_energy_rows(
+            trimmed,
+            entity_ids.values(),
+            date(2026, 1, 4),
+        )
+        self.assertEqual(
+            rows["sensor.heating"],
+            [(date(2026, 1, 2), 2.0), (date(2026, 1, 3), 2.0)],
+        )
+        self.assertEqual(totals["sensor.dhw"], 1.5)
+        self.assertEqual(totals["sensor.combined"], 3.0)
+        self.assertTrue(all(
+            current >= previous
+            for entity_rows in rows.values()
+            for previous, current in zip(
+                (value for _day, value in entity_rows),
+                (value for _day, value in entity_rows[1:]),
+            )
+        ))
+
+    def test_overlapping_cloud_windows_do_not_duplicate_days(self) -> None:
+        history = load_component_module("energy_history")
+        entity_ids = {"heating": "sensor.heating"}
+        day_values = {}
+        history.merge_energy_window(
+            day_values,
+            date(2026, 1, 4),
+            {"heating": [3.0, 4.0]},
+            entity_ids,
+            ("heating",),
+        )
+        history.merge_energy_window(
+            day_values,
+            date(2026, 1, 3),
+            {"heating": [1.0, 2.0, 99.0]},
+            entity_ids,
+            ("heating",),
+        )
+
+        self.assertEqual(sorted(day_values), [
+            date(2026, 1, 1),
+            date(2026, 1, 2),
+            date(2026, 1, 3),
+            date(2026, 1, 4),
+        ])
+        self.assertEqual(day_values[date(2026, 1, 3)]["sensor.heating"], 3.0)
+
+    def test_previous_offset_is_inferred_without_double_application(self) -> None:
+        history = load_component_module("energy_history")
+
+        self.assertEqual(history.infer_previous_live_offset(100.0, 3.0), 0.0)
+        self.assertEqual(history.infer_previous_live_offset(100.0, 100.0), 100.0)
+        self.assertEqual(history.infer_previous_live_offset(100.0, 105.0), 100.0)
+        self.assertEqual(history.infer_previous_live_offset(100.0, None), 0.0)
+
+    def test_coordinator_offsets_live_tables_and_waits_for_recorder(self) -> None:
+        source = (COMPONENT / "coordinator.py").read_text(encoding="utf-8")
+
+        self.assertIn("recorder.async_adjust_statistics(", source)
+        self.assertIn("await recorder.async_block_till_done()", source)
+        self.assertIn("_previous_energy_reimport_totals", source)
+        self.assertIn("EMPTY_HISTORY_STOP_DAYS", source)
 
 
 class ModbusAddressTests(unittest.TestCase):


### PR DESCRIPTION
## What changed

- Rebuild available Kronoterm Cloud energy history without creating years of synthetic zero statistics.
- Preserve the finalized-midnight to live-recorder handover in hourly and five-minute statistics.
- Prevent negative cumulative totals and duplicate offsets.
- Make repeated imports idempotent and serialize concurrent button presses.
- Update the integration and manifest versions to 1.7.1.

## Root cause

The previous importer scanned the full retention window, imported leading zero
history, and did not account for Home Assistant rewriting later sums while
imported rows were merged. A finalized midnight row on the handover date also
had to be distinguished from the first live non-midnight recorder row.

## User impact

The Reimport Energy Statistics button now imports the available Cloud history,
repairs older broken handovers, and leaves existing live statistics continuous.

## Validation

- 24 offline regression tests pass.
- Runtime-tested with Home Assistant 2026.7.3 and the configured Kronoterm Cloud device.
- Imported 1,892 days from 2021-05-17 through 2026-07-21.
- Verified zero negative sums and zero monotonic drops across all five hourly and five-minute energy series.
- Verified a second import produced identical row counts and totals.
- SQLite `quick_check` returned `ok`.
