### PR TITLE
Fix Home Assistant validation for v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   historical-to-live cumulative handover in both hourly and five-minute
   statistics, waits for the recorder to commit, and remains idempotent when
   pressed repeatedly.
+- Home Assistant validation now recognizes the recorder dependency and all
+  setup and reconfiguration steps use the supported translation structure.
 
 ## 2026-07-22 - v1.7.0
 

--- a/custom_components/kronoterm/__init__.py
+++ b/custom_components/kronoterm/__init__.py
@@ -3,6 +3,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_registry as er
 from .const import CONFIG_ENTRY_VERSION, DOMAIN
 from .coordinator import KronotermMainCoordinator, KronotermDHWCoordinator
@@ -16,6 +17,7 @@ from .identifiers import (
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = ["sensor", "binary_sensor", "switch", "climate", "select", "number", "button", "text"]
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/kronoterm/manifest.json
+++ b/custom_components/kronoterm/manifest.json
@@ -9,7 +9,8 @@
     "sensor",
     "binary_sensor",
     "number",
-    "climate"
+    "climate",
+    "recorder"
   ],
   "documentation": "https://github.com/Favio25/kronoterm-homeassistant",
   "integration_type": "device",

--- a/custom_components/kronoterm/strings.json
+++ b/custom_components/kronoterm/strings.json
@@ -20,10 +20,6 @@
           "cloud_type": "Select Heat Pump Type"
         }
       },
-      "cloud_type": {
-        "cloud": "Heating heat pump",
-        "dhw": "Sanitary water heat pump"
-      },
       "reauth_confirm": {
         "title": "Reconnect Kronoterm Cloud",
         "description": "Enter valid credentials for this Kronoterm Cloud connection.",
@@ -32,20 +28,95 @@
           "password": "Password"
         }
       },
-      "modbus": {
+      "modbus_transport": {
+        "title": "Modbus Transport",
+        "description": "Choose how Home Assistant connects to your heat pump",
+        "data": {
+          "transport": "Transport"
+        }
+      },
+      "modbus_tcp": {
         "title": "Modbus TCP Configuration",
         "description": "Configure local Modbus TCP connection to your heat pump",
         "data": {
           "host": "IP Address",
           "port": "Port",
           "unit_id": "Modbus Unit ID",
-          "model": "Heat Pump Model"
+          "timeout": "Timeout"
         },
         "data_description": {
           "host": "IP address of your Kronoterm heat pump on local network",
           "port": "Modbus TCP port (default: 502)",
           "unit_id": "Modbus slave address (default: 20)",
-          "model": "Select your heat pump model for accurate energy calculation"
+          "timeout": "Connection timeout in seconds"
+        }
+      },
+      "modbus_rtu": {
+        "title": "Modbus RTU Configuration",
+        "description": "Configure a local Modbus RTU connection to your heat pump",
+        "data": {
+          "serial_port": "Serial Port",
+          "baudrate": "Baud Rate",
+          "bytesize": "Data Bits",
+          "parity": "Parity",
+          "stopbits": "Stop Bits",
+          "timeout": "Timeout",
+          "unit_id": "Modbus Unit ID"
+        }
+      },
+      "reconfigure_connection_type": {
+        "title": "Change Connection Type",
+        "description": "Current connection: {current_type}. Choose a new connection type; existing entities will be preserved.",
+        "data": {
+          "connection_type": "Connection Type"
+        }
+      },
+      "reconfigure_cloud": {
+        "title": "Cloud API Configuration",
+        "description": "Configure the cloud connection; existing entities will be preserved.",
+        "data": {
+          "username": "Username",
+          "password": "Password",
+          "cloud_type": "Heat Pump Type"
+        },
+        "data_description": {
+          "cloud_type": "Select Heat Pump Type"
+        }
+      },
+      "reconfigure_modbus_transport": {
+        "title": "Modbus Transport",
+        "description": "Choose the new Modbus transport; existing entities will be preserved.",
+        "data": {
+          "transport": "Transport"
+        }
+      },
+      "reconfigure_modbus_tcp": {
+        "title": "Modbus TCP Configuration",
+        "description": "Configure the local Modbus TCP connection; existing entities will be preserved.",
+        "data": {
+          "host": "IP Address",
+          "port": "Port",
+          "unit_id": "Modbus Unit ID",
+          "timeout": "Timeout"
+        },
+        "data_description": {
+          "host": "IP address of your Kronoterm heat pump on local network",
+          "port": "Modbus TCP port (default: 502)",
+          "unit_id": "Modbus slave address (default: 20)",
+          "timeout": "Connection timeout in seconds"
+        }
+      },
+      "reconfigure_modbus_rtu": {
+        "title": "Modbus RTU Configuration",
+        "description": "Configure the local Modbus RTU connection; existing entities will be preserved.",
+        "data": {
+          "serial_port": "Serial Port",
+          "baudrate": "Baud Rate",
+          "bytesize": "Data Bits",
+          "parity": "Parity",
+          "stopbits": "Stop Bits",
+          "timeout": "Timeout",
+          "unit_id": "Modbus Unit ID"
         }
       }
     },
@@ -59,51 +130,6 @@
       "already_configured": "Device is already configured",
       "reauth_successful": "Kronoterm Cloud credentials updated successfully",
       "reconfigure_successful": "Reconfiguration successful. Entities preserved."
-    }
-  },
-  "reconfigure": {
-    "step": {
-      "reconfigure_connection_type": {
-        "title": "Change Connection Type",
-        "description": "Current connection: {current_type}. Choose new connection type (entities will be preserved)",
-        "data": {
-          "connection_type": "Connection Type"
-        }
-      },
-      "reconfigure_cloud": {
-        "title": "Cloud API Configuration",
-        "description": "Configure cloud connection (entities will be preserved)",
-        "data": {
-          "username": "Username",
-          "password": "Password",
-          "cloud_type": "Heat Pump Type"
-        },
-        "data_description": {
-          "cloud_type": "Select Heat Pump Type"
-        }
-      },
-      "reconfigure_modbus": {
-        "title": "Modbus TCP Configuration",
-        "description": "Configure local Modbus connection (entities will be preserved)",
-        "data": {
-          "host": "IP Address",
-          "port": "Port",
-          "unit_id": "Modbus Unit ID",
-          "model": "Heat Pump Model"
-        },
-        "data_description": {
-          "host": "IP address of your Kronoterm heat pump on local network",
-          "port": "Modbus TCP port (default: 502)",
-          "unit_id": "Modbus slave address (default: 20)",
-          "model": "Select your heat pump model for accurate energy calculation"
-        }
-      }
-    },
-    "error": {
-      "cannot_connect": "Failed to connect to the device. Please check the connection details.",
-      "cannot_read": "Connected but failed to read data from device. Check unit ID.",
-      "invalid_auth": "Invalid username or password.",
-      "unknown": "Unexpected error occurred. Check logs for details."
     }
   },
   "options": {

--- a/custom_components/kronoterm/translations/en.json
+++ b/custom_components/kronoterm/translations/en.json
@@ -20,10 +20,6 @@
           "cloud_type": "Select Heat Pump Type"
         }
       },
-      "cloud_type": {
-        "cloud": "Heating heat pump",
-        "dhw": "Sanitary water heat pump"
-      },
       "reauth_confirm": {
         "title": "Reconnect Kronoterm Cloud",
         "description": "Enter valid credentials for this Kronoterm Cloud connection.",
@@ -32,20 +28,95 @@
           "password": "Password"
         }
       },
-      "modbus": {
+      "modbus_transport": {
+        "title": "Modbus Transport",
+        "description": "Choose how Home Assistant connects to your heat pump",
+        "data": {
+          "transport": "Transport"
+        }
+      },
+      "modbus_tcp": {
         "title": "Modbus TCP Configuration",
         "description": "Configure local Modbus TCP connection to your heat pump",
         "data": {
           "host": "IP Address",
           "port": "Port",
           "unit_id": "Modbus Unit ID",
-          "model": "Heat Pump Model"
+          "timeout": "Timeout"
         },
         "data_description": {
           "host": "IP address of your Kronoterm heat pump on local network",
           "port": "Modbus TCP port (default: 502)",
           "unit_id": "Modbus slave address (default: 20)",
-          "model": "Select your heat pump model for accurate energy calculation"
+          "timeout": "Connection timeout in seconds"
+        }
+      },
+      "modbus_rtu": {
+        "title": "Modbus RTU Configuration",
+        "description": "Configure a local Modbus RTU connection to your heat pump",
+        "data": {
+          "serial_port": "Serial Port",
+          "baudrate": "Baud Rate",
+          "bytesize": "Data Bits",
+          "parity": "Parity",
+          "stopbits": "Stop Bits",
+          "timeout": "Timeout",
+          "unit_id": "Modbus Unit ID"
+        }
+      },
+      "reconfigure_connection_type": {
+        "title": "Change Connection Type",
+        "description": "Current connection: {current_type}. Choose a new connection type; existing entities will be preserved.",
+        "data": {
+          "connection_type": "Connection Type"
+        }
+      },
+      "reconfigure_cloud": {
+        "title": "Cloud API Configuration",
+        "description": "Configure the cloud connection; existing entities will be preserved.",
+        "data": {
+          "username": "Username",
+          "password": "Password",
+          "cloud_type": "Heat Pump Type"
+        },
+        "data_description": {
+          "cloud_type": "Select Heat Pump Type"
+        }
+      },
+      "reconfigure_modbus_transport": {
+        "title": "Modbus Transport",
+        "description": "Choose the new Modbus transport; existing entities will be preserved.",
+        "data": {
+          "transport": "Transport"
+        }
+      },
+      "reconfigure_modbus_tcp": {
+        "title": "Modbus TCP Configuration",
+        "description": "Configure the local Modbus TCP connection; existing entities will be preserved.",
+        "data": {
+          "host": "IP Address",
+          "port": "Port",
+          "unit_id": "Modbus Unit ID",
+          "timeout": "Timeout"
+        },
+        "data_description": {
+          "host": "IP address of your Kronoterm heat pump on local network",
+          "port": "Modbus TCP port (default: 502)",
+          "unit_id": "Modbus slave address (default: 20)",
+          "timeout": "Connection timeout in seconds"
+        }
+      },
+      "reconfigure_modbus_rtu": {
+        "title": "Modbus RTU Configuration",
+        "description": "Configure the local Modbus RTU connection; existing entities will be preserved.",
+        "data": {
+          "serial_port": "Serial Port",
+          "baudrate": "Baud Rate",
+          "bytesize": "Data Bits",
+          "parity": "Parity",
+          "stopbits": "Stop Bits",
+          "timeout": "Timeout",
+          "unit_id": "Modbus Unit ID"
         }
       }
     },
@@ -80,51 +151,6 @@
       "cannot_connect": "Failed to connect to the device.",
       "invalid_auth": "Invalid username or password.",
       "unknown": "Unexpected error occurred."
-    }
-  },
-  "reconfigure": {
-    "step": {
-      "reconfigure_connection_type": {
-        "title": "Change Connection Type",
-        "description": "Current connection: {current_type}. Choose new connection type (entities will be preserved)",
-        "data": {
-          "connection_type": "Connection Type"
-        }
-      },
-      "reconfigure_cloud": {
-        "title": "Cloud API Configuration",
-        "description": "Configure cloud connection (entities will be preserved)",
-        "data": {
-          "username": "Username",
-          "password": "Password",
-          "cloud_type": "Heat Pump Type"
-        },
-        "data_description": {
-          "cloud_type": "Select Heat Pump Type"
-        }
-      },
-      "reconfigure_modbus": {
-        "title": "Modbus TCP Configuration",
-        "description": "Configure local Modbus connection (entities will be preserved)",
-        "data": {
-          "host": "IP Address",
-          "port": "Port",
-          "unit_id": "Modbus Unit ID",
-          "model": "Heat Pump Model"
-        },
-        "data_description": {
-          "host": "IP address of your Kronoterm heat pump on local network",
-          "port": "Modbus TCP port (default: 502)",
-          "unit_id": "Modbus slave address (default: 20)",
-          "model": "Select your heat pump model for accurate energy calculation"
-        }
-      }
-    },
-    "error": {
-      "cannot_connect": "Failed to connect to the device. Please check the connection details.",
-      "cannot_read": "Connected but failed to read data from device. Check unit ID.",
-      "invalid_auth": "Invalid username or password.",
-      "unknown": "Unexpected error occurred. Check logs for details."
     }
   },
   "entity": {


### PR DESCRIPTION
## What changed

- declare Home Assistant's recorder integration as a runtime dependency
- add the config-entry-only YAML schema expected by hassfest
- move reconfiguration translations into the supported `config.step` structure
- align Modbus TCP and RTU translation keys with their actual config-flow steps
- document the validation fix in the v1.7.1 changelog

## Why

The v1.7.1 implementation passed its regression tests and HACS validation, but the re-enabled hassfest workflow rejected an undeclared recorder dependency and obsolete translation nesting.

## Validation

- 24 regression tests pass
- integration Python files compile successfully
- manifest and translation JSON parse successfully
- `strings.json` and `translations/en.json` config/options sections match
- `git diff --check` passes
