### PR TITLE
Add swimming-pool circuit support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+- Swimming-pool circuit support on both Cloud API and Modbus. The pool is
+  auto-detected and exposed as a climate entity (current temperature, target
+  setpoint, and Off/Normal/Schedule preset) plus eco/comfort offset numbers,
+  matching the existing heating loops and DHW. Pool setpoint, mode, and offset
+  changes are written back over both transports.
+
 ## 2026-07-23 - v1.7.1
 
 ### Fixed

--- a/custom_components/kronoterm/climate.py
+++ b/custom_components/kronoterm/climate.py
@@ -76,6 +76,11 @@ async def async_setup_entry(
         if coordinator.reservoir_installed:
             entities.append(KronotermModbusReservoirClimate(entry, coordinator))
             _LOGGER.debug("Reservoir installed, adding Modbus climate entity")
+
+        # Pool
+        if getattr(coordinator, "pool_installed", False):
+            entities.append(KronotermModbusPoolClimate(entry, coordinator))
+            _LOGGER.debug("Pool installed, adding Modbus climate entity")
     else:
         # Cloud API-based climate entities
         _LOGGER.info("Creating Cloud API-based climate entities")
@@ -100,7 +105,10 @@ async def async_setup_entry(
             if coordinator.reservoir_installed:
                 entities.append(KronotermReservoirClimate(entry, coordinator))
 
-    _LOGGER.debug("Created %d climate entities (%s mode)", 
+            if getattr(coordinator, "pool_installed", False):
+                entities.append(KronotermPoolClimate(entry, coordinator))
+
+    _LOGGER.debug("Created %d climate entities (%s mode)",
                    len(entities), "Modbus" if is_modbus else "Cloud API")
     async_add_entities(entities)
     return True
@@ -742,6 +750,74 @@ class KronotermReservoirClimate(KronotermJsonClimate):
             await self.coordinator.async_request_refresh()
 
 
+#
+#   Pool
+#
+class KronotermPoolClimate(KronotermJsonClimate):
+    """Climate entity for the swimming pool circuit."""
+
+    PRESET_MAP = {0: "OFF", 1: "ON", 2: "AUTO"}
+    PRESET_TO_VALUE = {v: k for k, v in PRESET_MAP.items()}
+
+    def __init__(self, entry: ConfigEntry, coordinator: DataUpdateCoordinator):
+        super().__init__(
+            entry=entry,
+            coordinator=coordinator,
+            data_key="pool",
+            current_temp_json_key="pool_temp",
+            target_temp_json_key="circle_temp",
+            current_temp_section="TemperaturesAndConfig",
+            fallback_name="Pool Thermostat",
+            translation_key="pool_temperature",
+            unique_id_suffix="pool_climate",
+            min_temp=20,
+            max_temp=35,
+            page=10,
+            supports_cooling=False,
+        )
+        self._attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
+        self._attr_preset_modes = list(self.PRESET_TO_VALUE.keys())
+
+    def _get_preset_value(self) -> Optional[int]:
+        data = self._json_data or {}
+        mode_blob = data.get("HeatingCircleData", {})
+        for key in ("mode", "operation_mode", "circle_mode", "loop_mode"):
+            raw = mode_blob.get(key)
+            if raw is None:
+                continue
+            try:
+                return int(float(raw))
+            except (TypeError, ValueError):
+                continue
+        return None
+
+    @property
+    def current_temperature(self) -> float | None:
+        return super().current_temperature
+
+    @property
+    def target_temperature(self) -> float | None:
+        return super().target_temperature
+
+    @property
+    def preset_mode(self) -> str | None:
+        value = self._get_preset_value()
+        if value is None:
+            return None
+        return self.PRESET_MAP.get(value)
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        value = self.PRESET_TO_VALUE.get(preset_mode)
+        if value is None:
+            _LOGGER.warning("Unknown pool preset_mode: %s", preset_mode)
+            return
+        success = await self.coordinator.async_set_loop_mode_by_page(self._page, value)
+        if not success:
+            _LOGGER.error("Failed to set pool preset_mode=%s (page=%s)", preset_mode, self._page)
+        else:
+            await self.coordinator.async_request_refresh()
+
+
 # ===================================================================
 # MODBUS-BASED CLIMATE ENTITIES
 # ===================================================================
@@ -1125,5 +1201,27 @@ class KronotermModbusReservoirClimate(KronotermModbusBaseClimate):
             target_temp_address=2034,  # reservoir_current_setpoint
             write_temp_address=getattr(coordinator, "reservoir_write_temp_address", 2305),
             operation_mode_address=2035,  # reservoir_operation_mode
+            enable_preset=True,
+        )
+
+
+class KronotermModbusPoolClimate(KronotermModbusBaseClimate):
+    """Modbus-based climate entity for the swimming pool circuit."""
+
+    def __init__(self, entry: ConfigEntry, coordinator: DataUpdateCoordinator):
+        super().__init__(
+            entry=entry,
+            coordinator=coordinator,
+            fallback_name="Pool Thermostat",
+            translation_key="pool_temperature",
+            unique_id_suffix="pool_climate",
+            min_temp=20,
+            max_temp=35,
+            current_temp_address=2109,  # pool_temperature
+            thermostat_temp_address=None,  # No thermostat for pool
+            target_temp_address=2080,  # pool_current_setpoint
+            write_temp_address=2079,  # pool_setpoint
+            operation_mode_address=2081,  # pool_operation_mode
+            supports_cooling=False,  # pool only heats
             enable_preset=True,
         )

--- a/custom_components/kronoterm/const.py
+++ b/custom_components/kronoterm/const.py
@@ -54,6 +54,7 @@ API_QUERIES_GET = {
     "loop3": {"TopPage": "1", "Subpage": "7"},
     "loop4": {"TopPage": "1", "Subpage": "8"},
     "dhw": {"TopPage": "1", "Subpage": "9"},
+    "pool": {"TopPage": "1", "Subpage": "10"},
     "consumption": {"TopPage": "4", "Subpage": "4", "Action": "4"},
     "main_settings": {"TopPage": "3", "Subpage": "11"},
     "system_data": {"TopPage": "1", "Subpage": "2"},
@@ -68,6 +69,7 @@ API_QUERIES_SET = {
     "loop3": {"TopPage": "1", "Subpage": "7", "Action": "1"},
     "loop4": {"TopPage": "1", "Subpage": "8", "Action": "1"},
     "dhw": {"TopPage": "1", "Subpage": "9", "Action": "1"},
+    "pool": {"TopPage": "1", "Subpage": "10", "Action": "1"},
     "main_settings": {"TopPage": "3", "Subpage": "11", "Action": "1"},
 }
 
@@ -94,6 +96,7 @@ PAGE_TO_SET_QUERY_KEY = {
     7: "loop3",
     8: "loop4",
     9: "dhw",
+    10: "pool",
 }
 
 # ----------------------------------------------------------------------------

--- a/custom_components/kronoterm/coordinator.py
+++ b/custom_components/kronoterm/coordinator.py
@@ -379,6 +379,7 @@ class KronotermMainCoordinator(KronotermBaseCoordinator):
                 "reservoir",
                 "loop3",
                 "loop4",
+                "pool",
                 "main_settings",
                 "system_data",
             )
@@ -1008,7 +1009,7 @@ class KronotermDHWCoordinator(KronotermBaseCoordinator):
             data["shortcuts"] = results[1] if not isinstance(results[1], Exception) else None
             
             # Nullify others to be safe
-            for key in ["loop1", "loop2", "dhw", "reservoir", "loop3", "loop4", "main_settings", "system_data", "info", "consumption"]:
+            for key in ["loop1", "loop2", "dhw", "reservoir", "loop3", "loop4", "pool", "main_settings", "system_data", "info", "consumption"]:
                 data[key] = None
                 
             return data

--- a/custom_components/kronoterm/modbus_coordinator.py
+++ b/custom_components/kronoterm/modbus_coordinator.py
@@ -692,10 +692,20 @@ class ModbusCoordinator(ModbusReadMixin, ModbusWriteMixin, DataUpdateCoordinator
         # Check if Reservoir is installed (has valid setpoint reading)
         reservoir_setpoint = data.get(2034, {}).get("value")
         self.reservoir_installed = reservoir_setpoint is not None and reservoir_setpoint > 0
-        
+
+        # Check if Pool is installed (has valid setpoint/temperature reading)
+        pool_setpoint = data.get(2080, {}).get("value")
+        pool_temp = data.get(2109, {}).get("value")
+        pool_enable = data.get(2020, {}).get("value")
+        self.pool_installed = (
+            (pool_setpoint is not None and pool_setpoint > 0)
+            or (pool_temp is not None and pool_temp > -50)
+            or bool(pool_enable)
+        )
+
         # Debug logging
-        _LOGGER.debug("Feature flags: loop2=%s, loop3=%s, loop4=%s, reservoir=%s (temps: %s, %s, %s, setpoint: %s)", 
-                       self.loop2_installed, self.loop3_installed, self.loop4_installed, self.reservoir_installed,
+        _LOGGER.debug("Feature flags: loop2=%s, loop3=%s, loop4=%s, reservoir=%s, pool=%s (temps: %s, %s, %s, setpoint: %s)",
+                       self.loop2_installed, self.loop3_installed, self.loop4_installed, self.reservoir_installed, self.pool_installed,
                        loop2_temp, loop3_temp, loop4_temp, reservoir_setpoint)
         
         # Check if additional source is installed

--- a/custom_components/kronoterm/modbus_writes.py
+++ b/custom_components/kronoterm/modbus_writes.py
@@ -100,6 +100,7 @@ class ModbusWriteMixin:
             5: 2187,  # Loop 1 setpoint
             6: 2049,  # Loop 2 setpoint
             9: 2023,  # DHW setpoint
+            10: 2079, # Pool setpoint
         }
         
         register_address = page_to_register.get(page)
@@ -140,6 +141,8 @@ class ModbusWriteMixin:
             (8, "circle_comfort_offset"): 2078,  # Loop 4 comfort
             (9, "circle_eco_offset"): 2030,      # DHW eco
             (9, "circle_comfort_offset"): 2031,  # DHW comfort
+            (10, "circle_eco_offset"): 2086,     # Pool eco
+            (10, "circle_comfort_offset"): 2087, # Pool comfort
         }
         
         register_address = offset_map.get((page, param_name))
@@ -192,6 +195,7 @@ class ModbusWriteMixin:
             7: 2062,  # Loop 3
             8: 2072,  # Loop 4
             9: 2026,  # DHW operation
+            10: 2081, # Pool operation mode
         }
         
         register_address = page_to_register.get(page)

--- a/custom_components/kronoterm/translations/de.json
+++ b/custom_components/kronoterm/translations/de.json
@@ -782,6 +782,9 @@
       },
       "reservoir_temperature": {
         "name": "Speicher-Thermostat"
+      },
+      "pool_temperature": {
+        "name": "Pool-Thermostat"
       }
     },
     "button": {

--- a/custom_components/kronoterm/translations/en.json
+++ b/custom_components/kronoterm/translations/en.json
@@ -933,6 +933,9 @@
       },
       "reservoir_temperature": {
         "name": "Reservoir Thermostat"
+      },
+      "pool_temperature": {
+        "name": "Pool Thermostat"
       }
     },
     "button": {

--- a/custom_components/kronoterm/translations/it.json
+++ b/custom_components/kronoterm/translations/it.json
@@ -782,6 +782,9 @@
       },
       "reservoir_temperature": {
         "name": "Termostato del serbatoio"
+      },
+      "pool_temperature": {
+        "name": "Termostato piscina"
       }
     },
     "button": {

--- a/custom_components/kronoterm/translations/sl.json
+++ b/custom_components/kronoterm/translations/sl.json
@@ -782,6 +782,9 @@
       },
       "reservoir_temperature": {
         "name": "Termostat rezervoarja"
+      },
+      "pool_temperature": {
+        "name": "Termostat bazena"
       }
     },
     "button": {

--- a/tests/test_pool_support.py
+++ b/tests/test_pool_support.py
@@ -1,0 +1,145 @@
+"""Offline regression checks for Modbus pool heat-loop support."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "kronoterm"
+
+
+def source(name: str) -> str:
+    return (COMPONENT / name).read_text(encoding="utf-8")
+
+
+def class_method_source(filename: str, class_name: str, method_name: str) -> str:
+    text = source(filename)
+    tree = ast.parse(text)
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef) or node.name != class_name:
+            continue
+        for child in node.body:
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and child.name == method_name:
+                return ast.get_source_segment(text, child) or ""
+    raise AssertionError(f"Method {class_name}.{method_name} not found in {filename}")
+
+
+POOL_REGISTERS = {
+    2079: "pool_setpoint",
+    2080: "pool_current_setpoint",
+    2081: "pool_operation_mode",
+    2086: "pool_eco_offset",
+    2087: "pool_comfort_offset",
+    2109: "pool_temperature",
+}
+
+
+class PoolLoopSupport(unittest.TestCase):
+    def test_modbus_coordinator_detects_pool_installed(self) -> None:
+        """pool_installed is derived from live readings, not left hardcoded False."""
+        flags = class_method_source(
+            "modbus_coordinator.py", "ModbusCoordinator", "_update_feature_flags"
+        )
+        self.assertIn("self.pool_installed", flags)
+        self.assertIn("2080", flags)
+        self.assertIn("2109", flags)
+
+    def test_modbus_offset_write_maps_pool_page_ten(self) -> None:
+        """Pool eco/comfort offsets write to their page-10 registers."""
+        offset = class_method_source(
+            "modbus_writes.py", "ModbusWriteMixin", "async_set_offset"
+        )
+        self.assertIn('(10, "circle_eco_offset"): 2086', offset)
+        self.assertIn('(10, "circle_comfort_offset"): 2087', offset)
+
+    def test_modbus_setpoint_and_mode_write_maps_pool_page_ten(self) -> None:
+        """Pool setpoint and operation mode resolve to their page-10 registers."""
+        setpoint = class_method_source(
+            "modbus_writes.py", "ModbusWriteMixin", "async_set_temperature"
+        )
+        self.assertIn("10: 2079", setpoint)
+        mode = class_method_source(
+            "modbus_writes.py", "ModbusWriteMixin", "async_set_loop_mode_by_page"
+        )
+        self.assertIn("10: 2081", mode)
+
+    def test_modbus_pool_climate_class_wires_the_right_registers(self) -> None:
+        """The pool climate reads temperature/setpoint and writes the pool setpoint."""
+        climate = source("climate.py")
+        self.assertIn("class KronotermModbusPoolClimate", climate)
+        cls = climate[climate.index("class KronotermModbusPoolClimate"):]
+        for token in (
+            'translation_key="pool_temperature"',
+            "current_temp_address=2109",
+            "target_temp_address=2080",
+            "write_temp_address=2079",
+            "operation_mode_address=2081",
+            "supports_cooling=False",
+            "enable_preset=True",
+        ):
+            self.assertIn(token, cls, token)
+
+    def test_modbus_pool_climate_registered_behind_install_flag(self) -> None:
+        """The pool climate is only created when the pool is installed."""
+        climate = source("climate.py")
+        self.assertIn("KronotermModbusPoolClimate(entry, coordinator)", climate)
+        self.assertIn('getattr(coordinator, "pool_installed", False)', climate)
+
+    def test_pool_offset_numbers_defined_for_page_ten(self) -> None:
+        """The eco/comfort offset numbers stay wired to the pool install flag."""
+        number = source("number.py")
+        self.assertIn(
+            'OffsetConfig("pool_eco_offset", 10, 2086, "circle_eco_offset", -10.0, 0.0, "pool_installed")',
+            number,
+        )
+        self.assertIn(
+            'OffsetConfig("pool_comfort_offset", 10, 2087, "circle_comfort_offset", 0.0, 10.0, "pool_installed")',
+            number,
+        )
+
+    def test_pool_registers_present_in_both_maps(self) -> None:
+        """Both controller maps expose the pool registers with the expected names."""
+        for filename in ("kronoterm.json", "kronoterm_tt3000.json"):
+            registers = {item["address"]: item for item in json.loads(source(filename))["registers"]}
+            for address, name_en in POOL_REGISTERS.items():
+                self.assertIn(address, registers, f"{address} missing from {filename}")
+                self.assertEqual(registers[address]["name_en"], name_en)
+
+    def test_pool_climate_and_sensor_names_stay_distinct(self) -> None:
+        """The pool climate name does not collide with the pool sensor name."""
+        for locale in ("en", "de", "it", "sl"):
+            climate = json.loads(source(f"translations/{locale}.json"))["entity"]["climate"]
+            self.assertIn("pool_temperature", climate)
+        english = json.loads(source("translations/en.json"))["entity"]
+        self.assertEqual(english["climate"]["pool_temperature"]["name"], "Pool Thermostat")
+        self.assertEqual(english["sensor"]["pool_temperature"]["name"], "Pool Temperature")
+
+    def test_cloud_pool_page_is_wired(self) -> None:
+        """The Cloud pool GET/SET pages and page->query mapping exist."""
+        const = source("const.py")
+        self.assertIn('"pool": {"TopPage": "1", "Subpage": "10"}', const)
+        self.assertIn('"pool": {"TopPage": "1", "Subpage": "10", "Action": "1"}', const)
+        self.assertIn('10: "pool"', const)
+
+    def test_cloud_coordinator_fetches_pool_page(self) -> None:
+        """The main Cloud coordinator fetches the pool page each update."""
+        updater = class_method_source(
+            "coordinator.py", "KronotermMainCoordinator", "_async_update_data"
+        )
+        self.assertIn('"pool"', updater)
+
+    def test_cloud_pool_climate_reads_pool_fields(self) -> None:
+        """The Cloud pool climate reads pool_temp and is created when installed."""
+        climate = source("climate.py")
+        self.assertIn("class KronotermPoolClimate(KronotermJsonClimate)", climate)
+        self.assertIn('data_key="pool"', climate)
+        self.assertIn('current_temp_json_key="pool_temp"', climate)
+        self.assertIn("KronotermPoolClimate(entry, coordinator)", climate)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Adds the swimming-pool circuit, exposed like the existing loops and DHW: a
**climate entity** (current temperature, target setpoint, Off/Normal/Schedule
preset) plus **eco/comfort offset** numbers, on both Cloud and Modbus. The pool
registers were already polled but nothing was exposed, and the Cloud side had no
pool page.

## Changes

**Cloud**
- Add the pool page (`TopPage=1, Subpage=10`) to the GET/SET queries and
  `PAGE_TO_SET_QUERY_KEY[10]`, and fetch it in the main coordinator update.
- New `KronotermPoolClimate` — reads `pool_temp` / `HeatingCircleData`, writes
  setpoint, mode, and offsets via page 10 (same `circle_*` params as the other
  circuits). Shown when `pool_active` is set.

**Modbus**
- Auto-detect `pool_installed`; add page-10 setpoint/mode/offset writes; new
  `KronotermModbusPoolClimate` mirroring the reservoir/DHW climate. The existing
  pool offset numbers now activate and write.

**Also:** pool climate translations (en/de/it/sl) and offline tests. The pool
registers are unchanged — from the existing documentation-sourced maps; this
only adds entity wiring and write paths.

## Testing

- **Cloud** — verified end-to-end on a live pool-equipped install: the climate
  shows the correct temperature/setpoint/mode, and setpoint, mode, and offset
  changes write back successfully.
- **Modbus** — follows the same pattern and address helper as the existing
  loop/DHW writes, but **not hardware-tested** (I have cloud-only access); it's
  inert unless Modbus mode + a pool are present.
- Offline test suite passes; no register-map/manifest/dependency changes, so
  hassfest/HACS validation is unaffected.
